### PR TITLE
Remove [removed] posts

### DIFF
--- a/Source/ShitRimWorldSays/ShitRimWorldSays/Post.cs
+++ b/Source/ShitRimWorldSays/ShitRimWorldSays/Post.cs
@@ -62,7 +62,7 @@ public class Post
             var reply = JsonConvert.DeserializeObject<Reply>(
                 JObject.Parse(await http.DownloadStringTaskAsync(address))["data"]["children"][0]["data"].ToString());
             var tipQuote = new Tip_Quote(reply.author, reply.body, reply.permalink, score);
-            return tipQuote.body == "[deleted]" ? null : tipQuote;
+            return (tipQuote.body == "[removed]" || tipQuote.body == "[deleted]") ? null : tipQuote;
         }
         catch (Exception)
         {
@@ -81,7 +81,7 @@ public class Post
                 JObject.Parse(await http.DownloadStringTaskAsync(address))["data"]["children"][0]["data"].ToString());
             var tipQuote = new Tip_Quote(post.author, post.is_self ? post.selftext : post.title, post.permalink,
                 score);
-            return tipQuote.body == "[deleted]" ? null : tipQuote;
+            return (tipQuote.body == "[removed]" || tipQuote.body == "[deleted]") ? null : tipQuote;
         }
         catch (Exception)
         {


### PR DESCRIPTION
On Reddit, if the OP deleted their own post ([example here](https://www.reddit.com/r/RimWorld/comments/1m3lk5i/)), the body of the tip will sometimes appear as ``[removed]``. This is entirely uninteresting (similar to ``[deleted]``) so I am proposing to remove them.  
This change does not affect existing quotes that this mod had already fetched and saved locally, the player might still see ``[removed]`` posts until they remove all such entries from their mod config file (or delete the mod config file entirely).  
An alternative, more aggressive approach for you to consider is to check by length of the post and remove extremely short posts (say < 10 characters), which would also remove [posts like this](https://www.reddit.com/r/RimWorld/comments/1m9uqkc/)).